### PR TITLE
Switch generic interfaces to cobra.Command

### DIFF
--- a/cobra.go
+++ b/cobra.go
@@ -235,7 +235,7 @@ func (b *cobraBuilder) addChildCommands(bC builderCallback, cfg interface{}, chi
 	return nil
 }
 
-func (b *cobraBuilder) customConfigure(f func(interface{})) {
+func (b *cobraBuilder) customConfigure(f func(*cobra.Command)) {
 	f(b._cmd)
 }
 

--- a/cobra_test.go
+++ b/cobra_test.go
@@ -744,7 +744,7 @@ func TestCobraBuilder_setHandler(t *testing.T) {
 	}
 
 	var expectedErr error = errors.New("we should get this back")
-	var h HandlerFunc = func(i interface{}, args []string) error {
+	var h HandlerFunc = func(i *cobra.Command, args []string) error {
 		return expectedErr
 	}
 
@@ -927,11 +927,7 @@ func TestCobraBuidler_customConfigure(t *testing.T) {
 		_cmd: &cobra.Command{},
 	}
 
-	cb.customConfigure(func(i interface{}) {
-		cmd, ok := i.(*cobra.Command)
-
-		assert.True(t, ok)
-
+	cb.customConfigure(func(cmd *cobra.Command) {
 		cmd.Use = "blah"
 	})
 

--- a/command.go
+++ b/command.go
@@ -2,6 +2,8 @@ package clapp
 
 import (
 	"context"
+
+	"github.com/spf13/cobra"
 )
 
 type ValueType string
@@ -12,7 +14,7 @@ const IntFlag ValueType = "int"
 const IntSliceFlag ValueType = "intslice"
 const BoolFlag ValueType = "bool"
 
-type HandlerFunc func(interface{}, []string) error
+type HandlerFunc func(*cobra.Command, []string) error
 
 type Descriptions struct {
 	Long  string
@@ -33,8 +35,8 @@ type Command struct {
 	Descriptions        Descriptions
 	LocalFlags          []Flag
 	PersistentFlags     []Flag
-	Handle              func(interface{}, []string) error
-	CustomConfiguration func(interface{})
+	Handle              HandlerFunc
+	CustomConfiguration func(*cobra.Command)
 	Children            []Command
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -142,20 +142,16 @@ child:
 		},
 
 		// The function that is actually called when this command is run.
-		Handle: func(cmd interface{}, args []string) error {
-			// The library is designed so that cobra could be replaced later
-			// We'll typeassert it to the underlying type here so we can access it like a normal cobra handler
-			cobraCmd := cmd.(*cobra.Command)
-
+		Handle: func(cmd *cobra.Command, args []string) error {
 			// Now we get the config from the context
 			// Again the config could be of any type, so we need to typeassert here
-			cfg := clapp.ConfigFromContext(cobraCmd.Context()).(*myconfig)
+			cfg := clapp.ConfigFromContext(cmd.Context()).(*myconfig)
 
 			// Print out the values of the config
 			fmt.Printf("GlobalVar is:       %s\n", cfg.GlobalVar)
 			fmt.Printf("MyConfigVar var is: %s\n", cfg.MyConfigVar)
 			fmt.Printf("AnotherVar var is:  %s\n", anotherVar)
-			fmt.Printf("Command version is: %s\n", cobraCmd.Version)
+			fmt.Printf("Command version is: %s\n", cmd.Version)
 
 			return nil
 		},
@@ -163,11 +159,9 @@ child:
 		// This allows you to run a function on the underlying command
 		// It provides a way to do more complex operations on the underlying command
 		// We don't have to provide every property of the command by allowing this
-		CustomConfiguration: func(cmd interface{}) {
-			cobraCmd := cmd.(*cobra.Command)
-
+		CustomConfiguration: func(cmd *cobra.Command) {
 			// Just an example of modifying the underlying command
-			cobraCmd.Version = "1.1.1"
+			cmd.Version = "1.1.1"
 		},
 
 		Children: []clapp.Command{
@@ -204,20 +198,16 @@ child:
 				},
 		
 				// The function that is actually called when this command is run.
-				Handle: func(cmd interface{}, args []string) error {
-					// The library is designed so that cobra could be replaced later
-					// We'll typeassert it to the underlying type here so we can access it like a normal cobra handler
-					cobraCmd := cmd.(*cobra.Command)
-		
+				Handle: func(cmd *cobra.Command, args []string) error {
 					// Now we get the config from the context
 					// Again the config could be of any type, so we need to typeassert here
-					cfg := clapp.ConfigFromContext(cobraCmd.Context()).(*myconfig)
+					cfg := clapp.ConfigFromContext(cmd.Context()).(*myconfig)
 		
 					// Print out the values of the config
 					fmt.Printf("GlobalVar is:       %s\n", cfg.GlobalVar)
 					fmt.Printf("MyConfigVar var is: %s\n", cfg.MyConfigVar)
 					fmt.Printf("AnotherVar var is:  %s\n", anotherVar)
-					fmt.Printf("Command version is: %s\n", cobraCmd.Version)
+					fmt.Printf("Command version is: %s\n", cmd.Version)
 					fmt.Printf("Required value is:  %d\n", required)
 		
 					return nil
@@ -226,11 +216,9 @@ child:
 				// This allows you to run a function on the underlying command
 				// It provides a way to do more complex operations on the underlying command
 				// We don't have to provide every property of the command by allowing this
-				CustomConfiguration: func(cmd interface{}) {
-					cobraCmd := cmd.(*cobra.Command)
-		
+				CustomConfiguration: func(cmd *cobra.Command) {
 					// Just an example of modifying the underlying command
-					cobraCmd.Version = "1.3.1"
+					cmd.Version = "1.3.1"
 				},
 			},
 		},


### PR DESCRIPTION
In a couple of places the library was designed to be unneccessarily
generic. The command handler functions would expect a generic
interface which would need to be type asserted before you can do
anything useful with it. In these places I replaced it for the
concrete implementation of cobra.Command, to make the library
simpler to use.